### PR TITLE
Add template render method context

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ spec contexts.
   - URL: `https://w3id.org/vc/render-method/v2rc1`
   - Short name: `v2rc1`
   - Status: under development
+- VC Render Method v2rc2 context
+  - URL: `https://w3id.org/vc/render-method/v2rc2`
+  - Short name: `v2rc2`
+  - Status: under development
 
 ## Developing
 

--- a/contexts/v2rc2.jsonld
+++ b/contexts/v2rc2.jsonld
@@ -1,0 +1,42 @@
+{
+  "@context": {
+    "@protected": true,
+    "id": "@id",
+    "type": "@type",
+    "TemplateRenderMethod": {
+      "@id": "https://w3id.org/vc/render-method#TemplateRenderMethod",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "description": "https://schema.org/description",
+        "name": "https://schema.org/name",
+        "renderSuite": "https://w3id.org/vc/render-method#renderSuite",
+        "renderProperty": {
+          "@id": "https://w3id.org/vc/render-method#renderProperty",
+          "@container": "@set"
+        },
+        "outputPreference": {
+          "@id": "https://w3id.org/vc/render-method#outputPreference",
+          "@context": {
+            "@protected": true,
+            "id": "@id",
+            "mode": {
+              "@id": "https://w3id.org/vc/render-method#mode",
+              "@container": "@set"
+            },
+            "mediaType": "https://schema.org/encodingFormat",
+            "style": {
+              "@id": "https://w3id.org/vc/render-method#style",
+              "@type": "@json"
+            }
+          }
+        },
+        "template": {
+          "@id": "https://w3id.org/vc/render-method#template",
+          "@type": "@id"
+        }
+      }
+    }
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
  */
 import v1Context from './v1.js';
 import v2rc1Context from './v2rc1.js';
+import v2rc2Context from './v2rc2.js';
 
 // map of context id to context
 export const contexts = new Map();
@@ -37,5 +38,15 @@ setExportsFromMetadata({
     shortName: 'v2rc1',
     fileUrl: new URL('../contexts/v2rc1.jsonld', import.meta.url),
     context: v2rc1Context
+  }
+});
+setExportsFromMetadata({
+  contextsMap: contexts, metadataMap: metadata, namedMap: named,
+  metadata: {
+    id: 'https://w3id.org/vc/render-method/v2rc2',
+    type: 'ContextMetadata',
+    shortName: 'v2rc2',
+    fileUrl: new URL('../contexts/v2rc2.jsonld', import.meta.url),
+    context: v2rc2Context
   }
 });

--- a/lib/v2rc2.js
+++ b/lib/v2rc2.js
@@ -91,3 +91,4 @@ export default
     }
   }
 }
+/* context-end */;

--- a/lib/v2rc2.js
+++ b/lib/v2rc2.js
@@ -78,16 +78,6 @@ export default
           "@type": "@id"
         }
       }
-    },
-    "NfcRenderingTemplate2024": {
-      "@id": "https://w3id.org/vc/render-method#NfcRenderingTemplate2024",
-      "@context": {
-        "@protected": true,
-        "id": "@id",
-        "type": "@type",
-        "name": "https://schema.org/name",
-        "payload": "https://w3id.org/vc/render-method#payload"
-      }
     }
   }
 }

--- a/lib/v2rc2.js
+++ b/lib/v2rc2.js
@@ -52,7 +52,7 @@ export default
         "type": "@type",
         "description": "https://schema.org/description",
         "name": "https://schema.org/name",
-        "renderEngine": "https://w3id.org/vc/render-method#renderEngine",
+        "renderSuite": "https://w3id.org/vc/render-method#renderSuite",
         "renderProperty": {
           "@id": "https://w3id.org/vc/render-method#renderProperty",
           "@container": "@set"

--- a/lib/v2rc2.js
+++ b/lib/v2rc2.js
@@ -1,0 +1,93 @@
+/*!
+ * Copyright (c) 2026 Digital Bazaar, Inc. All rights reserved.
+ */
+// Use JSON style for context
+/* eslint quotes: ['error', 'double'] */
+/* eslint quote-props: ['error', 'always'] */
+/* eslint-disable max-len */
+
+export default
+/* context-url: https://w3id.org/vc/render-method/v2rc2 */
+/* context-begin */
+{
+  "@context": {
+    "@protected": true,
+    "id": "@id",
+    "type": "@type",
+    "SvgRenderingTemplate2023": {
+      "@id": "https://w3id.org/vc/render-method#SvgRenderingTemplate2023",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "css3MediaQuery": "https://w3id.org/vc/render-method#css3MediaQuery",
+        "digestMultibase": {
+          "@id": "https://w3id.org/security#digestMultibase",
+          "@type": "https://w3id.org/security#multibase"
+        },
+        "name": "https://schema.org/name"
+      }
+    },
+    "SvgRenderingTemplate2024": {
+      "@id": "https://w3id.org/vc/render-method#SvgRenderingTemplate2024",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "digestMultibase": {
+          "@id": "https://w3id.org/security#digestMultibase",
+          "@type": "https://w3id.org/security#multibase"
+        },
+        "mediaQuery": "https://w3id.org/vc/render-method#mediaQuery",
+        "mediaType": "https://schema.org/encodingFormat",
+        "name": "https://schema.org/name",
+        "template": "https://w3id.org/vc/render-method#template"
+      }
+    },
+    "TemplateRenderMethod": {
+      "@id": "https://w3id.org/vc/render-method#TemplateRenderMethod",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "description": "https://schema.org/description",
+        "name": "https://schema.org/name",
+        "renderEngine": "https://w3id.org/vc/render-method#renderEngine",
+        "renderProperty": {
+          "@id": "https://w3id.org/vc/render-method#renderProperty",
+          "@container": "@set"
+        },
+        "outputPreference": {
+          "@id": "https://w3id.org/vc/render-method#outputPreference",
+          "@context": {
+            "@protected": true,
+            "id": "@id",
+            "mode": {
+              "@id": "https://w3id.org/vc/render-method#mode",
+              "@container": "@set"
+            },
+            "mediaType": "https://schema.org/encodingFormat",
+            "style": {
+              "@id": "https://w3id.org/vc/render-method#style",
+              "@type": "@json"
+            }
+          }
+        },
+        "template": {
+          "@id": "https://w3id.org/vc/render-method#template",
+          "@type": "@id"
+        }
+      }
+    },
+    "NfcRenderingTemplate2024": {
+      "@id": "https://w3id.org/vc/render-method#NfcRenderingTemplate2024",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "name": "https://schema.org/name",
+        "payload": "https://w3id.org/vc/render-method#payload"
+      }
+    }
+  }
+}

--- a/lib/v2rc2.js
+++ b/lib/v2rc2.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2026 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2026 Digital Bazaar, Inc.
  */
 // Use JSON style for context
 /* eslint quotes: ['error', 'double'] */

--- a/lib/v2rc2.js
+++ b/lib/v2rc2.js
@@ -14,36 +14,6 @@ export default
     "@protected": true,
     "id": "@id",
     "type": "@type",
-    "SvgRenderingTemplate2023": {
-      "@id": "https://w3id.org/vc/render-method#SvgRenderingTemplate2023",
-      "@context": {
-        "@protected": true,
-        "id": "@id",
-        "type": "@type",
-        "css3MediaQuery": "https://w3id.org/vc/render-method#css3MediaQuery",
-        "digestMultibase": {
-          "@id": "https://w3id.org/security#digestMultibase",
-          "@type": "https://w3id.org/security#multibase"
-        },
-        "name": "https://schema.org/name"
-      }
-    },
-    "SvgRenderingTemplate2024": {
-      "@id": "https://w3id.org/vc/render-method#SvgRenderingTemplate2024",
-      "@context": {
-        "@protected": true,
-        "id": "@id",
-        "type": "@type",
-        "digestMultibase": {
-          "@id": "https://w3id.org/security#digestMultibase",
-          "@type": "https://w3id.org/security#multibase"
-        },
-        "mediaQuery": "https://w3id.org/vc/render-method#mediaQuery",
-        "mediaType": "https://schema.org/encodingFormat",
-        "name": "https://schema.org/name",
-        "template": "https://w3id.org/vc/render-method#template"
-      }
-    },
     "TemplateRenderMethod": {
       "@id": "https://w3id.org/vc/render-method#TemplateRenderMethod",
       "@context": {

--- a/test/context.common.cjs
+++ b/test/context.common.cjs
@@ -4,17 +4,17 @@
 module.exports.tests = function({contexts, metadata, named, expect}) {
   it('contexts', async () => {
     expect(metadata).to.exist;
-    expect(metadata.size).to.equal(2);
+    expect(metadata.size).to.equal(3);
   });
 
   it('metadata', async () => {
     expect(metadata).to.exist;
-    expect(metadata.size).to.equal(2);
+    expect(metadata.size).to.equal(3);
   });
 
   it('named', async () => {
     expect(named).to.exist;
-    expect(named.size).to.equal(2);
+    expect(named.size).to.equal(3);
   });
 
   it('contents', async () => {
@@ -26,6 +26,10 @@ module.exports.tests = function({contexts, metadata, named, expect}) {
       {
         id: 'https://w3id.org/vc/render-method/v2rc1',
         name: 'v2rc1'
+      },
+      {
+        id: 'https://w3id.org/vc/render-method/v2rc2',
+        name: 'v2rc2'
       }
     ];
 


### PR DESCRIPTION
**Note:** 

- If `v2rc2` name is not accurate please guide me.
- @dlongley this also includes renaming `renderEngine` to `renderSuite`. **Context:** NFC work.

**Disclaimer:** `v2rc2` also contains below `NfcRenderingTemplate2024` which was used in some legacy `nfc` related demos. I would like to point out that this specific method type was not in any of previous release `v1` or `v1rc1`. So if not required I can remove that. My intention to keep it was for backward compatibility.

```
"NfcRenderingTemplate2024": {
      "@id": "https://w3id.org/vc/render-method#NfcRenderingTemplate2024",
      "@context": {
        "@protected": true,
        "id": "@id",
        "type": "@type",
        "name": "https://schema.org/name",
        "payload": "https://w3id.org/vc/render-method#payload"
      }
    }
```

@dlongley @davidlehn @BigBlueHat cc: @msporny 

Ready for review.